### PR TITLE
Enable -Wall

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.2.0)
+cmake_minimum_required(VERSION 3.12.0)
 project(ZeroPilot C CXX ASM)
 
 set(ELF_NAME ${PROJECT_NAME}.elf)
@@ -54,6 +54,15 @@ set(STARTUP_ASM_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Boardfiles/${STARTUP_ASM})
 set(LINKER_SCRIPT_FILE ${CMAKE_CURRENT_SOURCE_DIR}/Boardfiles/${LINKER_SCRIPT})
 
 add_executable(${ELF_NAME} ${C_SOURCES} ${CXX_SOURCES} ${STARTUP_ASM_FILE})
+
+# Specify C standard we use
+set_property(TARGET ${ELF_NAME} PROPERTY C_STANDARD 11)
+set_property(TARGET ${ELF_NAME} PROPERTY CXX_STANDARD 20)
+
+# Error on warnings, enable all warnings
+target_compile_options(${ELF_NAME} PRIVATE
+  -Werror -Wall -Wextra -Wpedantic
+)
 
 # Add project-specific linker flags (.ld script, .map file)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -T${LINKER_SCRIPT_FILE} -Wl,-Map=${PROJECT_BINARY_DIR}/${PROJECT_NAME}.map,--cref")


### PR DESCRIPTION
## Description

*What was completed, changed, or updated?* 
I have included the in the build options flags to enable all warnings and cause builds to fail when these errors occur.
<br/>

*Why was this done (if applicable)?*
It is good practice to reduce the number of warnings in our code, in fact these warnings can often cause bugs. Adding these warnings will help us to improve the quality of our code

These changes aren't necessarily required, but I implemented them in order to check my code. I believe they would be useful for the team at large. 

I believe we only use the gnu compilers, so these build flags should work across platforms, but this has not been tested.
<br/>


## Testing

*What **manual** tests were used to validate the code?*
I built the code
<br/>

*What **unit** tests were used to validate the code?*
N/A
<br/>


## Documentation

*Milestone number and name:*

*Link to Asana task:*

*Link to Confluence documentation:*

<br/>

