### PR TITLE
Add clang-format from old repo

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,5 @@
+﻿---
+BasedOnStyle: Google
+ColumnLimit: 100
+IndentWidth: '4'
+...


### PR DESCRIPTION
## Description

*What was completed, changed, or updated?* 
Add clang-format from old zp3 repo
<br/>

*Why was this done (if applicable)?*
To be used to enforce formatting rules in the future. Can be used now locally by individuals to autoformat their code
<br/>