### PR TITLE
PWM out driver

### DIFF
--- a/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
@@ -5,7 +5,6 @@
 
 class MotorChannel {
     public:
-        virtual void setup(void) = 0;
         virtual void set(uint8_t percent) = 0;
     protected:
         bool isSetup = false;

--- a/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
@@ -1,0 +1,14 @@
+#ifndef ZP_D_MOTOR_CHANNEL_HPP_
+#define ZP_D_MOTOR_CHANNEL_HPP_
+
+#include <cstdint>
+
+class MotorChannel {
+    public:
+        virtual void setup(void) = 0;
+        virtual void set(uint8_t percent) = 0;
+    protected:
+        bool isSetup = false;
+};
+
+#endif // ZP_D_MOTOR_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_MotorChannel.hpp
@@ -6,8 +6,6 @@
 class MotorChannel {
     public:
         virtual void set(uint8_t percent) = 0;
-    protected:
-        bool isSetup = false;
 };
 
 #endif // ZP_D_MOTOR_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -15,12 +15,10 @@ class PWMChannel : public MotorChannel {
         TIM_HandleTypeDef *timer;
         const uint16_t TIMER_CHANNEL;
 
-    	//set to minimum and max amount of counts in a duty cycle
+    	// set to minimum and max amount of counts in a duty cycle
         const uint32_t MIN_SIGNAL;
         const uint32_t MAX_SIGNAL;
-
-        const uint32_t CLOCK_FREQUENCY = SystemCoreClock;    //system clock frequency
-        const uint16_t DESIRED_FREQUENCY = 50; //PWM frequency in hz
+        const uint16_t DESIRED_FREQUENCY = 50; // PWM frequency in hz
 };
 
 #endif // ZP_D_PWM_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -7,27 +7,20 @@
 
 class PWMChannel : public MotorChannel {
     public:
-        PWMChannel(uint16_t pin_num, GPIO_TypeDef* port, TIM_HandleTypeDef* timer,
-					uint16_t timer_channel,uint32_t clock_frequency);
+        PWMChannel(TIM_HandleTypeDef* timer,
+					uint16_t timer_channel);
 
-        void setup(void);
         void set(uint8_t percent);
     private:
-        uint16_t pin_num_;
-        GPIO_TypeDef* port_;
-        TIM_HandleTypeDef *timer_;     //handle to the timer
-        uint16_t timer_channel_;       //channel of the timer
-        uint32_t clock_frequency_;     //system clock frequency
-        uint32_t period_ticks_;
+    	//set to minimum and max amount of counts in a duty cycle
+        uint32_t MIN_SIGNAL;
+        uint32_t MAX_SIGNAL;
+        uint32_t PERIOD_TICKS_;  
+        TIM_HandleTypeDef *TIMER_;     //handle to the timer
+        const uint16_t TIMER_CHANNEL_;   //channel of the timer
 
-        //set to min and max amount of counts in a duty cycle
-        uint32_t min_signal;
-        uint32_t max_signal;
-
-        //values in microseconds(us)
-        const uint16_t DESIRED_FREQUENCY = 50;
-
-
+        const uint32_t CLOCK_FREQUENCY_ = SystemCoreClock;    //system clock frequency
+        const uint16_t DESIRED_FREQUENCY = 50; //PWM frequency in hz
 };
 
 #endif // ZP_D_PWM_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -1,0 +1,32 @@
+#ifndef ZP_D_PWM_CHANNEL_HPP_
+#define ZP_D_PWM_CHANNEL_HPP_
+
+#include "main.h"
+
+#include "ZP_D_MotorChannel.hpp"
+
+class PWMChannel : public MotorChannel {
+    public:
+        PWMChannel(uint16_t pin_num, GPIO_TypeDef* port, TIM_HandleTypeDef* timer,
+					uint16_t timer_channel,uint32_t clock_frequency);
+
+        void setup(void);
+        void set(uint8_t percent);
+    private:
+        uint16_t pin_num_;
+        GPIO_TypeDef* port_;
+        TIM_HandleTypeDef *timer_;     //handle to the timer
+        uint16_t timer_channel_;       //channel of the timer
+        uint32_t clock_frequency_;     //system clock frequency
+        uint32_t period_ticks_;
+
+        //values in microseconds(us)
+        static constexpr uint32_t PWM_PERIOD = 20000;
+        static constexpr uint32_t MIN_SIGNAL = 950; //standard for 50hz pwm signal, with a 100 Hz margin added to ensure we can reach the extreme values.
+        static constexpr uint32_t MAX_SIGNAL = 2050;
+        const uint16_t DESIRED_FREQUENCY = 50;
+
+
+};
+
+#endif // ZP_D_PWM_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -12,15 +12,15 @@ class PWMChannel : public MotorChannel {
 
         void set(uint8_t percent);
     private:
-    	// set to minimum and max amount of counts in a duty cycle
-        uint32_t minSignal;
-        uint32_t maxSignal;
-        uint32_t PERIOD_TICKS;
-        TIM_HandleTypeDef *TIMER;     // handle to the timer
-        const uint16_t TIMER_CHANNEL;   // channel of the timer
+        TIM_HandleTypeDef *timer;
+        const uint16_t TIMER_CHANNEL;
 
-        const uint32_t CLOCK_FREQUENCY = SystemCoreClock;  // system clock frequency
-        const uint16_t DESIRED_FREQUENCY = 50; // PWM frequency in hz
+    	//set to minimum and max amount of counts in a duty cycle
+        const uint32_t MIN_SIGNAL;
+        const uint32_t MAX_SIGNAL;
+
+        const uint32_t CLOCK_FREQUENCY = SystemCoreClock;    //system clock frequency
+        const uint16_t DESIRED_FREQUENCY = 50; //PWM frequency in hz
 };
 
 #endif // ZP_D_PWM_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -20,10 +20,11 @@ class PWMChannel : public MotorChannel {
         uint32_t clock_frequency_;     //system clock frequency
         uint32_t period_ticks_;
 
+        //set to min and max amount of counts in a duty cycle
+        uint32_t min_signal;
+        uint32_t max_signal;
+
         //values in microseconds(us)
-        static constexpr uint32_t PWM_PERIOD = 20000;
-        static constexpr uint32_t MIN_SIGNAL = 950; //standard for 50hz pwm signal, with a 100 Hz margin added to ensure we can reach the extreme values.
-        static constexpr uint32_t MAX_SIGNAL = 2050;
         const uint16_t DESIRED_FREQUENCY = 50;
 
 

--- a/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
+++ b/Drivers/MotorChannel/Inc/ZP_D_PWMChannel.hpp
@@ -8,19 +8,19 @@
 class PWMChannel : public MotorChannel {
     public:
         PWMChannel(TIM_HandleTypeDef* timer,
-					uint16_t timer_channel);
+					uint16_t timerChannel);
 
         void set(uint8_t percent);
     private:
-    	//set to minimum and max amount of counts in a duty cycle
-        uint32_t MIN_SIGNAL;
-        uint32_t MAX_SIGNAL;
-        uint32_t PERIOD_TICKS_;  
-        TIM_HandleTypeDef *TIMER_;     //handle to the timer
-        const uint16_t TIMER_CHANNEL_;   //channel of the timer
+    	// set to minimum and max amount of counts in a duty cycle
+        uint32_t minSignal;
+        uint32_t maxSignal;
+        uint32_t PERIOD_TICKS;
+        TIM_HandleTypeDef *TIMER;     // handle to the timer
+        const uint16_t TIMER_CHANNEL;   // channel of the timer
 
-        const uint32_t CLOCK_FREQUENCY_ = SystemCoreClock;    //system clock frequency
-        const uint16_t DESIRED_FREQUENCY = 50; //PWM frequency in hz
+        const uint32_t CLOCK_FREQUENCY = SystemCoreClock;  // system clock frequency
+        const uint16_t DESIRED_FREQUENCY = 50; // PWM frequency in hz
 };
 
 #endif // ZP_D_PWM_CHANNEL_HPP_

--- a/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
+++ b/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
@@ -1,29 +1,29 @@
 #include "ZP_D_PWMChannel.hpp"
 
 PWMChannel::PWMChannel(TIM_HandleTypeDef* timer,
-                        uint16_t timer_channel) :
-                        TIMER_(timer),
-                        TIMER_CHANNEL_(timer_channel)
+                        uint16_t timerChannel) :
+                        TIMER(timer),
+                        TIMER_CHANNEL(timerChannel)
 {
-	/*Sets up the PWM, pre-scaler, duty cycle ranges,
+	/* Sets up the PWM, pre-scaler, duty cycle ranges,
 	 * and starts the timer*/
-	PERIOD_TICKS_ = TIMER_->Init.Period;
-	MIN_SIGNAL = PERIOD_TICKS_ * 0.05; // sets counts for 5% duty cycle
-	MAX_SIGNAL = PERIOD_TICKS_ * 0.10; // sets counts for 10% duty cycle
+	PERIOD_TICKS = TIMER->Init.Period;
+	minSignal= PERIOD_TICKS * 0.05; // sets counts for 5% duty cycle
+	maxSignal = PERIOD_TICKS * 0.10; // sets counts for 10% duty cycle
 
-	//Calculate new pre-scaler
-	uint16_t prescaler_ = (CLOCK_FREQUENCY_ / DESIRED_FREQUENCY
-			/ PERIOD_TICKS_) - 1;
+	// Calculate new pre-scaler
+	uint16_t prescaler = (CLOCK_FREQUENCY / DESIRED_FREQUENCY
+			/ PERIOD_TICKS) - 1;
 
-	__HAL_TIM_SET_PRESCALER(TIMER_, prescaler_);
-	HAL_TIM_PWM_Start(TIMER_, TIMER_CHANNEL_);
+	__HAL_TIM_SET_PRESCALER(TIMER, prescaler);
+	HAL_TIM_PWM_Start(TIMER, TIMER_CHANNEL);
 
 
 	isSetup = true;
 }
 
 void PWMChannel::set(uint8_t percent) {
-	/*Sets the duty cycle as a percent between 5 and 10%.
+	/* Sets the duty cycle as a percent between 5 and 10%.
 	 *
 	 * Usage:
 	 * 0% corresponds to a duty cycle of 5%
@@ -32,8 +32,8 @@ void PWMChannel::set(uint8_t percent) {
     if (percent > 100 || !isSetup) {
         return;
     }
-    uint32_t ticks = (percent * (MAX_SIGNAL - MIN_SIGNAL)) / 100 + MIN_SIGNAL;
+    uint32_t ticks = (percent * (maxSignal - minSignal)) / 100 + minSignal;
 
-    __HAL_TIM_SET_COMPARE(TIMER_, TIMER_CHANNEL_, ticks);
+    __HAL_TIM_SET_COMPARE(TIMER, TIMER_CHANNEL, ticks);
 }
 

--- a/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
+++ b/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
@@ -8,14 +8,14 @@ PWMChannel::PWMChannel(TIM_HandleTypeDef* timer,
                         MAX_SIGNAL(timer->Init.Period * 0.10)  // sets counts for 10% duty cycle
 {
 	// Calculate new pre-scaler
-	uint16_t prescaler = (CLOCK_FREQUENCY / DESIRED_FREQUENCY
+	uint16_t prescaler = (SystemCoreClock / DESIRED_FREQUENCY
 			/ timer->Init.Period) - 1;
 	__HAL_TIM_SET_PRESCALER(timer, prescaler);
 	HAL_TIM_PWM_Start(timer, TIMER_CHANNEL);
 }
 
 void PWMChannel::set(uint8_t percent) {
-	/*Sets the duty cycle as a percent between 5 and 10%.
+	/* Sets the duty cycle as a percent between 5 and 10%.
 	 *
 	 * Usage:
 	 * 0% corresponds to a duty cycle of 5%

--- a/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
+++ b/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
@@ -1,0 +1,35 @@
+#include "ZP_D_PWMChannel.hpp"
+
+PWMChannel::PWMChannel(uint16_t pin_num, GPIO_TypeDef* port, TIM_HandleTypeDef* timer,
+                        uint16_t timer_channel, uint32_t clock_frequency) :    pin_num_(pin_num),
+                                                    port_(port),
+                                                    timer_(timer),
+                                                    timer_channel_(timer_channel),clock_frequency_(clock_frequency) {}
+
+void PWMChannel::setup(void) {
+	period_ticks_ = timer_->Init.Period;
+
+	uint16_t prescaler_ = (clock_frequency_ / DESIRED_FREQUENCY / PWM_PERIOD) - 1;
+
+	//set timer settings and start pwm
+	__HAL_TIM_SET_PRESCALER(timer_, prescaler_);
+	__HAL_TIM_SET_COUNTER(timer_, PWM_PERIOD);
+	HAL_TIM_PWM_Start(timer_, timer_channel_);
+
+
+	isSetup = true;
+}
+
+
+void PWMChannel::set(uint8_t percent) {
+    if (percent > 100 || !isSetup) {
+        return;
+    }
+
+    uint32_t us = (percent * (MAX_SIGNAL - MIN_SIGNAL)) / 100 + MIN_SIGNAL;
+    uint32_t ticks = static_cast<uint32_t>((static_cast<float>(us) / static_cast<float>(PWM_PERIOD))
+                        * static_cast<float>(period_ticks_));
+
+    __HAL_TIM_SET_COMPARE(timer_, timer_channel_, ticks);
+}
+

--- a/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
+++ b/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
@@ -1,29 +1,26 @@
 #include "ZP_D_PWMChannel.hpp"
 
-PWMChannel::PWMChannel(uint16_t pin_num, GPIO_TypeDef* port, TIM_HandleTypeDef* timer,
-                        uint16_t timer_channel, uint32_t clock_frequency) :    pin_num_(pin_num),
-                                                    port_(port),
-                                                    timer_(timer),
-                                                    timer_channel_(timer_channel),clock_frequency_(clock_frequency) {}
-
-void PWMChannel::setup(void) {
-	/*Sets up the PWM, prescaler, duty cycle ranges,
+PWMChannel::PWMChannel(TIM_HandleTypeDef* timer,
+                        uint16_t timer_channel) :
+                        TIMER_(timer),
+                        TIMER_CHANNEL_(timer_channel)
+{
+	/*Sets up the PWM, pre-scaler, duty cycle ranges,
 	 * and starts the timer*/
-	period_ticks_ = timer_->Init.Period;
-	min_signal = period_ticks_ * 0.05; // sets counts for 5% duty cycle
-	max_signal = period_ticks_ * 0.10; // sets counts for 10% duty cycle
+	PERIOD_TICKS_ = TIMER_->Init.Period;
+	MIN_SIGNAL = PERIOD_TICKS_ * 0.05; // sets counts for 5% duty cycle
+	MAX_SIGNAL = PERIOD_TICKS_ * 0.10; // sets counts for 10% duty cycle
 
-	//Calculate new prescaler
-	uint16_t prescaler_ = (clock_frequency_ / DESIRED_FREQUENCY
-			/ period_ticks_) - 1;
+	//Calculate new pre-scaler
+	uint16_t prescaler_ = (CLOCK_FREQUENCY_ / DESIRED_FREQUENCY
+			/ PERIOD_TICKS_) - 1;
 
-	__HAL_TIM_SET_PRESCALER(timer_, prescaler_);
-	HAL_TIM_PWM_Start(timer_, timer_channel_);
+	__HAL_TIM_SET_PRESCALER(TIMER_, prescaler_);
+	HAL_TIM_PWM_Start(TIMER_, TIMER_CHANNEL_);
 
 
 	isSetup = true;
 }
-
 
 void PWMChannel::set(uint8_t percent) {
 	/*Sets the duty cycle as a percent between 5 and 10%.
@@ -35,8 +32,8 @@ void PWMChannel::set(uint8_t percent) {
     if (percent > 100 || !isSetup) {
         return;
     }
-    uint32_t ticks = (percent * (max_signal - min_signal)) / 100 + min_signal;
+    uint32_t ticks = (percent * (MAX_SIGNAL - MIN_SIGNAL)) / 100 + MIN_SIGNAL;
 
-    __HAL_TIM_SET_COMPARE(timer_, timer_channel_, ticks);
+    __HAL_TIM_SET_COMPARE(TIMER_, TIMER_CHANNEL_, ticks);
 }
 

--- a/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
+++ b/Drivers/MotorChannel/Src/ZP_D_PWMChannel.cpp
@@ -2,38 +2,30 @@
 
 PWMChannel::PWMChannel(TIM_HandleTypeDef* timer,
                         uint16_t timerChannel) :
-                        TIMER(timer),
-                        TIMER_CHANNEL(timerChannel)
+						timer(timer),
+                        TIMER_CHANNEL(timerChannel),
+						MIN_SIGNAL(timer->Init.Period * 0.05),  // sets counts for 5% duty cycle
+                        MAX_SIGNAL(timer->Init.Period * 0.10)  // sets counts for 10% duty cycle
 {
-	/* Sets up the PWM, pre-scaler, duty cycle ranges,
-	 * and starts the timer*/
-	PERIOD_TICKS = TIMER->Init.Period;
-	minSignal= PERIOD_TICKS * 0.05; // sets counts for 5% duty cycle
-	maxSignal = PERIOD_TICKS * 0.10; // sets counts for 10% duty cycle
-
 	// Calculate new pre-scaler
 	uint16_t prescaler = (CLOCK_FREQUENCY / DESIRED_FREQUENCY
-			/ PERIOD_TICKS) - 1;
-
-	__HAL_TIM_SET_PRESCALER(TIMER, prescaler);
-	HAL_TIM_PWM_Start(TIMER, TIMER_CHANNEL);
-
-
-	isSetup = true;
+			/ timer->Init.Period) - 1;
+	__HAL_TIM_SET_PRESCALER(timer, prescaler);
+	HAL_TIM_PWM_Start(timer, TIMER_CHANNEL);
 }
 
 void PWMChannel::set(uint8_t percent) {
-	/* Sets the duty cycle as a percent between 5 and 10%.
+	/*Sets the duty cycle as a percent between 5 and 10%.
 	 *
 	 * Usage:
 	 * 0% corresponds to a duty cycle of 5%
 	 * 100% corresponds to a duty cycle of 10%
 	 * 50% corresponds to a duty cycle of 7.5%*/
-    if (percent > 100 || !isSetup) {
+    if (percent > 100) {
         return;
     }
-    uint32_t ticks = (percent * (maxSignal - minSignal)) / 100 + minSignal;
+    uint32_t ticks = (percent * (MAX_SIGNAL - MIN_SIGNAL)) / 100 + MIN_SIGNAL;
 
-    __HAL_TIM_SET_COMPARE(TIMER, TIMER_CHANNEL, ticks);
+    __HAL_TIM_SET_COMPARE(timer, TIMER_CHANNEL, ticks);
 }
 


### PR DESCRIPTION
## Description

*What was completed, changed, or updated?* 
PWM Output Driver for ZP 3.5. 
Tested LOS PWM out driver. Added functionality to read system clock, and auto set prescaler based on desired frequency. 
By default the desired frequency is 50hz.

<!-- Description done -->


*Why was this done (if applicable)?*
<!-- Explain or mark as "N/A" below . . . -->
Required Driver
<!-- Explanation done -->
<br/>


## Testing

*What **manual** tests were used to validate the code?*
Tested manually on Seleae Logic Analyzer, with an input clock frequency of 48 MHz. 

Comfirmed a constant~50hz frequency, with between ~5-10.25% duty cycle. (There is a small margin of error above and below 5 and 10%). 

Repeatedly input percent between 5 and 10%, confirming that it will reliably output the correct duty cycle.


<!-- Manual test listing done -->
<br/>

*What **unit** tests were used to validate the code?*
None so far, in progress.

I aim to test this with varying system clocks.

<!-- Unit test listing done -->
<br/>


## Documentation

*Milestone number and name:*

[*Link to Asana task:*](https://app.asana.com/0/home/1203900823953668/1204698388503807)

[*Link to Confluence documentation:*](https://uwarg-docs.atlassian.net/wiki/spaces/ZP/pages/2251817033/PWM+Out)

<br/>


## Reminders

- [x] Add reviewers to the PR

- [x] Mention the PR in the appropriate discord channel 
